### PR TITLE
feat: WebUI Agent Chat

### DIFF
--- a/agent/context.py
+++ b/agent/context.py
@@ -142,7 +142,7 @@ class ContextManager:
         if not registry:
             return ""
         try:
-            all_cmds = registry.get_all_commands()
+            all_cmds = registry.get_visible_commands()
             if not all_cmds:
                 return ""
             lines = []

--- a/agent/services/chat_api.py
+++ b/agent/services/chat_api.py
@@ -1,0 +1,199 @@
+"""WebUI Chat WebSocket endpoint — bridges browser ↔ MessageBus ↔ AgentLoop."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+from pathlib import Path
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, UploadFile, File
+from fastapi.responses import FileResponse
+from loguru import logger
+
+from bus.events import InboundMessage, OutboundMessage
+
+if TYPE_CHECKING:
+    from bus.queue import MessageBus
+
+chat_router = APIRouter()
+
+# Will be injected by gateway_server at import time
+_bus: MessageBus | None = None
+_agent_loop = None  # AgentLoop reference for history access
+
+CHANNEL = "webui"
+CHAT_ID = "webui_default"
+SENDER_ID = "webui_user"
+
+
+def init_chat_api(bus: MessageBus, agent_loop=None) -> None:
+    """Called once from gateway_server to inject the shared MessageBus."""
+    global _bus, _agent_loop
+    _bus = bus
+    _agent_loop = agent_loop
+
+
+@chat_router.get("/api/chat/commands")
+async def list_commands():
+    """Return visible (non-hidden) commands for UI autocomplete."""
+    try:
+        from config.registry import ConfigRegistry
+        registry = ConfigRegistry()
+        cmds = registry.get_visible_commands()
+        return [
+            {
+                "name": c.name,
+                "description": c.description,
+                "args_usage": c.args_usage,
+                "requires_args": c.requires_args,
+            }
+            for c in cmds.values()
+        ]
+    except Exception:
+        return []
+
+
+@chat_router.get("/api/chat/history")
+async def get_history(limit: int = 50):
+    """Return recent chat history for the webui session."""
+    if not _agent_loop:
+        return []
+    try:
+        history = await _agent_loop.history_logger.get_recent_history(
+            chat_id=CHAT_ID, limit=limit,
+        )
+        return [
+            {"role": msg["role"], "content": msg["content"]}
+            for msg in history
+            if msg.get("content")
+        ]
+    except Exception:
+        return []
+
+
+@chat_router.get("/api/chat/file")
+async def download_file(path: str):
+    """Serve a workspace file for download."""
+    p = Path(path)
+    if not p.is_absolute() or not p.exists() or not p.is_file():
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="File not found")
+    response = FileResponse(p, filename=p.name)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    return response
+
+
+@chat_router.post("/api/chat/upload")
+async def upload_file(file: UploadFile = File(...)):
+    """Upload a file and return its path for use in chat messages."""
+    if not _agent_loop:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=503, detail="Agent not ready")
+    upload_dir = Path(_agent_loop.workspace) / ".uploads"
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    dest = upload_dir / file.filename
+    # Avoid overwriting
+    if dest.exists():
+        stem, suffix = dest.stem, dest.suffix
+        i = 1
+        while dest.exists():
+            dest = upload_dir / f"{stem}_{i}{suffix}"
+            i += 1
+    content = await file.read()
+    dest.write_bytes(content)
+    return {"path": str(dest), "name": dest.name, "size": len(content)}
+
+
+@chat_router.websocket("/ws/chat")
+async def ws_chat(websocket: WebSocket):
+    await websocket.accept()
+    if _bus is None:
+        await websocket.close(code=1011, reason="MessageBus not initialised")
+        return
+
+    outbound_queue: asyncio.Queue[OutboundMessage] = asyncio.Queue()
+    closed = False
+
+    async def _on_outbound(msg: OutboundMessage) -> None:
+        """Subscriber callback — enqueue outbound messages for this client."""
+        if closed:
+            return
+        await outbound_queue.put(msg)
+
+    _bus.subscribe_outbound(CHANNEL, _on_outbound)
+    logger.info("WebUI chat client connected")
+
+    async def _sender():
+        """Forward queued outbound messages to the browser."""
+        nonlocal closed
+        try:
+            while not closed:
+                try:
+                    msg = await asyncio.wait_for(outbound_queue.get(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+
+                if msg.is_chunk:
+                    payload = {
+                        "type": "chunk",
+                        "content": msg.content,
+                        "stream_id": msg.stream_id or "main",
+                        "new_message": msg.new_message,
+                    }
+                else:
+                    payload = {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": msg.content,
+                        "is_notification": msg.is_notification,
+                        "media": msg.media or [],
+                    }
+                try:
+                    await websocket.send_text(json.dumps(payload, ensure_ascii=False))
+                except Exception:
+                    closed = True
+                    return
+        except asyncio.CancelledError:
+            pass
+
+    sender_task = asyncio.create_task(_sender())
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            msg_type = data.get("type")
+            content = (data.get("content") or "").strip()
+            if not content:
+                continue
+
+            if msg_type == "message":
+                media = data.get("media") or []
+                inbound = InboundMessage(
+                    channel=CHANNEL,
+                    sender_id=SENDER_ID,
+                    chat_id=CHAT_ID,
+                    content=content,
+                    media=media,
+                )
+                await _bus.publish_inbound(inbound)
+                # Echo back to confirm receipt
+                echo = {"type": "message", "role": "user", "content": content, "media": media}
+                await websocket.send_text(json.dumps(echo, ensure_ascii=False))
+                # Notify busy
+                await websocket.send_text(json.dumps({"type": "status", "busy": True}))
+
+    except (WebSocketDisconnect, Exception) as exc:
+        if not isinstance(exc, WebSocketDisconnect):
+            logger.debug(f"WebUI chat ws error: {exc}")
+    finally:
+        closed = True
+        _bus.unsubscribe_outbound(CHANNEL, _on_outbound)
+        sender_task.cancel()
+        logger.info("WebUI chat client disconnected")

--- a/agent/services/commands.py
+++ b/agent/services/commands.py
@@ -922,11 +922,47 @@ class CleanupHandler(BaseCommandHandler):
 
 
 def build_help_text(in_project: bool = False) -> str:
-    """Build user-facing help text with available commands."""
-    if in_project:
-        return t("help.text_zh")
-    else:
-        return t("help.text_zh_no_project")
+    """Build user-facing help text dynamically from commands.json (single source of truth)."""
+    try:
+        from config.registry import ConfigRegistry
+        registry = ConfigRegistry()
+        cmds = registry.get_visible_commands()
+    except Exception:
+        # Fallback to static i18n text if registry fails
+        return t("help.text_zh") if in_project else t("help.text_zh_no_project")
+
+    general_lines = []
+    project_lines = []
+    task_lines = []
+
+    for name, cmd in cmds.items():
+        desc = cmd.description
+        usage = cmd.args_usage.split("\n")[0] if cmd.args_usage else ""
+        # Use args_usage first line as display if it starts with the command name
+        if usage.startswith(name):
+            line = f"  {usage}"
+        elif cmd.requires_args:
+            line = f"  {name} ... — {desc}"
+        else:
+            line = f"  {name}  — {desc}"
+
+        if name in ("/task", "/start", "/done"):
+            task_lines.append(line)
+        elif cmd.require_project:
+            project_lines.append(line)
+        else:
+            general_lines.append(line)
+
+    sections = ["📖 Available Commands:\n"]
+    if general_lines:
+        sections.append("General:\n" + "\n".join(general_lines))
+    if project_lines:
+        label = "Project:" if in_project else "Project (enter a project first):"
+        sections.append(label + "\n" + "\n".join(project_lines))
+    if task_lines:
+        sections.append("Task Mode:\n" + "\n".join(task_lines))
+    sections.append("\n💡 You can also chat in natural language — I'll use the right tools automatically.")
+    return "\n\n".join(sections)
 
 
 def build_greeting_text() -> str:

--- a/agent/services/gateway_server.py
+++ b/agent/services/gateway_server.py
@@ -57,6 +57,10 @@ bus = MessageBus()
 im_runtime = get_im_runtime(bus)
 automation_runtime: Optional[AutomationRuntime] = None
 
+# WebUI Chat (router registered here, init deferred until after agent_loop is created)
+from agent.services.chat_api import chat_router, init_chat_api
+app.include_router(chat_router)
+
 # Global chat contact registry
 _chat_registry: Optional[ChatContactRegistry] = None
 
@@ -91,6 +95,7 @@ agent_loop = AgentLoop(
     workspace=_gw_workspace,
     model=_gw_model,
 )
+init_chat_api(bus, agent_loop)
 
 
 class JobSchedulePayload(BaseModel):

--- a/config/commands.json
+++ b/config/commands.json
@@ -3,20 +3,20 @@
     {
       "name": "/help",
       "handler": "agent.services.commands.HelpHandler",
-      "description": "显示可用命令列表",
+      "description": "Show all available commands and usage",
       "aliases": ["/?"],
       "requires_args": false
     },
     {
       "name": "/reset",
       "handler": "agent.services.commands.ResetHandler",
-      "description": "Reset the current session and clear history",
+      "description": "Clear conversation history and start a fresh session",
       "requires_args": false
     },
     {
       "name": "/stop",
       "handler": "agent.services.commands.StopHandler",
-      "description": "Stop current operation",
+      "description": "Force-cancel the current operation and its spawned background tasks",
       "aliases": ["/quit"],
       "requires_args": false
     },
@@ -24,13 +24,15 @@
       "name": "/summarize",
       "handler": "agent.services.commands.SummarizeHandler",
       "description": "Summarize current context into active memory",
-      "requires_args": false
+      "requires_args": false,
+      "hidden": true
     },
     {
       "name": "/recommend",
       "handler": "agent.services.commands.RecommendHandler",
       "description": "Detect latest project and research SOTA",
-      "requires_args": false
+      "requires_args": false,
+      "hidden": true
     },
     {
       "name": "/back",
@@ -42,7 +44,7 @@
     {
       "name": "/compile",
       "handler": "agent.services.commands.CompileHandler",
-      "description": "Compile LaTeX to PDF",
+      "description": "Compile the project LaTeX source into PDF",
       "aliases": ["/build"],
       "requires_args": false,
       "require_project": true
@@ -50,69 +52,74 @@
     {
       "name": "/sync",
       "handler": "agent.services.commands.SyncHandler",
-      "description": "Overleaf sync (pull or push)",
+      "description": "Sync project files with Overleaf",
       "aliases": ["/overleaf"],
       "requires_args": false,
-      "args_usage": "/sync [pull|push]",
+      "args_usage": "/sync pull — download from Overleaf (default)\n/sync push — upload local changes to Overleaf",
       "require_project": true
     },
     {
       "name": "/git",
       "handler": "agent.services.commands.GitHandler",
-      "description": "进入 Git 版本管理模式（多轮对话）",
+      "description": "Enter Git version control sub-session",
       "requires_args": false,
-      "require_project": true
+      "require_project": true,
+      "hidden": true
     },
     {
       "name": "/radar",
       "handler": "agent.services.commands.RadarHandler",
-      "description": "管理研究雷达自动化任务（status/subscribe/jobs/bootstrap/run/autoplan）",
+      "description": "Manage research radar automation jobs",
       "requires_args": false,
-      "args_usage": "/radar [status|subscribe|jobs|bootstrap [replace]|run <job_id>|autoplan run]",
-      "require_project": true
+      "args_usage": "/radar [status|subscribe|jobs|bootstrap|run <job_id>|autoplan run]",
+      "require_project": true,
+      "hidden": true
     },
     {
       "name": "/cleanup",
       "handler": "agent.services.commands.CleanupHandler",
       "description": "Clean up subagent working directories",
       "requires_args": false,
-      "require_project": true
+      "require_project": true,
+      "hidden": true
     },
     {
       "name": "/pull-project",
       "handler": "agent.services.commands.PullProjectHandler",
-      "description": "Sync project with Overleaf and Git commit (legacy, use /sync pull)",
+      "description": "Sync project with Overleaf and Git commit",
       "requires_args": false,
-      "require_project": true
+      "require_project": true,
+      "hidden": true
     },
     {
       "name": "/task",
       "handler": "agent.services.commands.TaskHandler",
-      "description": "Launch interactive task session (use --auto for legacy background mode)",
+      "description": "Enter interactive task mode for multi-step research goals",
       "aliases": ["/deepresearch"],
       "requires_args": false,
-      "args_usage": "/task [--auto] [--new] [goal]",
+      "args_usage": "/task <goal> — propose a plan, then /start to execute\n/task --e2e <goal> — fully automatic: plan + execute + commit with no confirmation",
       "tool_name": "task_planner",
       "tool_arg_key": "request"
     },
     {
       "name": "/start",
       "handler": "agent.services.commands.TaskStartHandler",
-      "description": "Begin task execution (TASK mode, PLAN → EXECUTE transition only)",
+      "description": "Approve the proposed task plan and begin execution (requires /task first)",
       "requires_args": false
     },
     {
       "name": "/done",
       "handler": "agent.services.commands.TaskDoneHandler",
-      "description": "End current TASK session and return to NORMAL mode",
+      "description": "Exit task mode, generate a summary and restore normal mode (requires /task first)",
       "requires_args": false
     },
     {
       "name": "/switch",
       "handler": "agent.services.commands.SwitchProjectHandler",
-      "description": "Switch to a specific project (handled by project tool)",
+      "description": "Switch to a project in the workspace",
       "requires_args": true,
-      "args_usage": "/switch <project_name>"
+      "args_usage": "/switch <project_name> — switch to project and create a new session\n/switch <project_name> <MMDD_NN> — resume a specific session",
+      "require_project": false
     }
   ]
 }

--- a/config/registry.py
+++ b/config/registry.py
@@ -47,6 +47,7 @@ class CommandDef:
     args_usage: str = ""
     tool_name: str = ""
     tool_arg_key: str = ""
+    hidden: bool = False
 
 
 @dataclass(frozen=True)
@@ -151,6 +152,7 @@ class ConfigRegistry:
                 args_usage=entry.get("args_usage", ""),
                 tool_name=entry.get("tool_name", ""),
                 tool_arg_key=entry.get("tool_arg_key", ""),
+                hidden=entry.get("hidden", False),
             )
             self._commands[cmd.name] = cmd
             for alias in cmd.aliases:
@@ -210,6 +212,10 @@ class ConfigRegistry:
 
     def get_all_commands(self) -> dict[str, CommandDef]:
         return dict(self._commands)
+
+    def get_visible_commands(self) -> dict[str, CommandDef]:
+        """Return commands that are not hidden — single source of truth for UI and system prompt."""
+        return {k: v for k, v in self._commands.items() if not v.hidden}
 
     def list_command_names(self) -> list[str]:
         """All command names including aliases."""

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -1989,6 +1989,111 @@
             </div>
         </div>
 
+        <!-- Chat Tab -->
+        <div x-show="tab === 'chat'" x-cloak class="h-[calc(100vh-10rem)] flex flex-col">
+            <!-- Toolbar -->
+            <div class="flex items-center justify-between mb-4">
+                <div class="flex items-center gap-3">
+                    <div class="w-2.5 h-2.5 rounded-full" :class="chatConnected ? 'bg-green-500 animate-pulse' : 'bg-red-500'"></div>
+                    <span class="text-sm text-gray-400" x-text="chatConnected ? (language === 'en' ? 'Connected' : 'WebSocket 已连接') : (language === 'en' ? 'Disconnected' : 'WebSocket 未连接')"></span>
+                    <span x-show="chatBusy" class="text-xs text-amber-400 flex items-center gap-1.5"><i class="fas fa-spinner fa-spin"></i> <span x-text="language === 'en' ? 'Agent thinking...' : 'Agent 思考中...'"></span></span>
+                </div>
+                <button @click="chatReset()"
+                        class="text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1.5">
+                    <i class="fas fa-rotate-right"></i>
+                    <span x-text="language === 'en' ? 'New Conversation' : '新建对话'"></span>
+                </button>
+            </div>
+
+            <!-- Messages -->
+            <div x-ref="chatScroll" class="flex-1 overflow-y-auto space-y-4 pr-2 pb-4" style="scroll-behavior:smooth">
+                <template x-if="chatMessages.length === 0">
+                    <div class="flex items-center justify-center h-full">
+                        <div class="text-center text-gray-500">
+                            <i class="fas fa-comment-dots text-4xl mb-3 opacity-30"></i>
+                            <p x-text="language === 'en' ? 'Send a message to start chatting' : '发送消息开始对话'"></p>
+                        </div>
+                    </div>
+                </template>
+                <template x-for="(msg, idx) in chatMessages" :key="idx">
+                    <div :class="msg.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
+                        <div :class="msg.role === 'user'
+                            ? 'bg-blue-600 text-white rounded-2xl rounded-br-md px-4 py-2.5 max-w-[75%]'
+                            : 'bg-gray-800 border border-gray-700 text-gray-200 rounded-2xl rounded-bl-md px-4 py-2.5 max-w-[85%]'">
+                            <pre class="whitespace-pre-wrap break-words text-sm font-sans leading-relaxed m-0" x-text="msg.content"></pre>
+                            <template x-if="msg.media && msg.media.length">
+                                <div class="mt-2 space-y-1">
+                                    <template x-for="f in msg.media" :key="f">
+                                        <a :href="'/api/chat/file?path=' + encodeURIComponent(f)"
+                                           target="_blank"
+                                           class="inline-flex items-center gap-1.5 text-xs text-blue-400 hover:text-blue-300 bg-black/20 rounded-lg px-2.5 py-1.5">
+                                            <i class="fas fa-file-download"></i>
+                                            <span x-text="f.split('/').pop()"></span>
+                                        </a>
+                                    </template>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                </template>
+            </div>
+
+            <!-- Input -->
+            <div class="mt-2 relative">
+                <!-- Command autocomplete popup -->
+                <div x-ref="chatCmdPanel" x-show="chatCmdShow && chatCmdFiltered.length > 0" x-cloak
+                     class="absolute bottom-full mb-1 left-0 right-0 bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden z-30 max-h-64 overflow-y-auto">
+                    <template x-for="(cmd, i) in chatCmdFiltered" :key="cmd.name">
+                        <button @click="chatCmdSelect(cmd)" @mouseenter="chatCmdIdx = i"
+                                :data-cmd-idx="i"
+                                class="w-full px-4 py-2.5 flex items-start gap-3 text-left transition-colors"
+                                :class="i === chatCmdIdx ? 'bg-blue-600/30 text-white' : 'text-gray-300 hover:bg-gray-800'">
+                            <span class="font-mono text-blue-400 text-sm flex-shrink-0 whitespace-nowrap" x-text="cmd.name"></span>
+                            <div class="min-w-0">
+                                <div class="text-xs text-gray-300 leading-relaxed" x-text="cmd.description"></div>
+                                <div x-show="cmd.args_usage" class="text-xs text-gray-500 font-mono mt-0.5 whitespace-pre-line" x-text="cmd.args_usage"></div>
+                            </div>
+                        </button>
+                    </template>
+                </div>
+                <div class="bg-gray-800 border border-gray-700 rounded-2xl p-3">
+                <div x-show="chatPendingFiles.length" class="flex flex-wrap gap-2 mb-2">
+                    <template x-for="(f, i) in chatPendingFiles" :key="f.path">
+                        <span class="inline-flex items-center gap-1.5 text-xs bg-gray-700 text-gray-300 rounded-lg px-2.5 py-1.5">
+                            <i class="fas fa-paperclip text-gray-500"></i>
+                            <span x-text="f.name"></span>
+                            <button @click="chatPendingFiles.splice(i, 1)" class="text-gray-500 hover:text-red-400 ml-0.5">&times;</button>
+                        </span>
+                    </template>
+                </div>
+                <div class="flex items-end gap-3">
+                <textarea x-ref="chatInput" x-model="chatInput"
+                    @keydown.enter="if(!$event.shiftKey && !$event.isComposing){ $event.preventDefault(); chatCmdShow ? chatCmdSelect(chatCmdFiltered[chatCmdIdx]) : chatSend() }"
+                    @keydown.arrow-up.prevent="if(chatCmdShow){ chatCmdIdx = Math.max(0, chatCmdIdx - 1); chatCmdScrollTo() }"
+                    @keydown.arrow-down.prevent="if(chatCmdShow){ chatCmdIdx = Math.min(chatCmdFiltered.length - 1, chatCmdIdx + 1); chatCmdScrollTo() }"
+                    @keydown.tab.prevent="chatCmdShow && chatCmdFiltered.length ? chatCmdSelect(chatCmdFiltered[chatCmdIdx]) : null"
+                    @keydown.escape="chatCmdShow = false"
+                    @input="chatCmdFilter(); $el.style.height='auto'; $el.style.height = Math.min($el.scrollHeight, 160) + 'px'"
+                    rows="1"
+                    :placeholder="language === 'en' ? 'Type a message... (Shift+Enter for newline)' : '输入消息... (Shift+Enter 换行)'"
+                    class="flex-1 bg-transparent text-gray-100 placeholder-gray-500 resize-none outline-none text-sm leading-relaxed max-h-40 overflow-y-auto"
+                ></textarea>
+                <input type="file" x-ref="chatFileInput" class="hidden" @change="chatUploadFile($event)" multiple />
+                <button @click="$refs.chatFileInput.click()" :disabled="!chatConnected"
+                    class="w-9 h-9 flex-shrink-0 rounded-xl flex items-center justify-center transition-colors"
+                    :class="chatConnected ? 'text-gray-400 hover:text-white hover:bg-gray-700' : 'text-gray-600 cursor-not-allowed'">
+                    <i class="fas fa-paperclip text-sm"></i>
+                </button>
+                <button @click="chatSend()" :disabled="(!chatInput.trim() && !chatPendingFiles.length) || !chatConnected"
+                    class="w-9 h-9 flex-shrink-0 rounded-xl flex items-center justify-center transition-colors"
+                    :class="(chatInput.trim() || chatPendingFiles.length) && chatConnected ? 'bg-blue-600 hover:bg-blue-500 text-white' : 'bg-gray-700 text-gray-500 cursor-not-allowed'">
+                    <i class="fas fa-paper-plane text-sm"></i>
+                </button>
+                </div>
+                </div>
+            </div>
+        </div>
+
     </main>
 
     <!-- Global Toast -->
@@ -2497,7 +2602,8 @@
                     { id: 'subscriptions', label: '推送管理', labelEn: 'Push Subscriptions', icon: 'fas fa-bell', desc: '用于获取定时任务执行推送信息的订阅配置', descEn: 'Manage subscriptions for scheduled task notifications' },
                     { id: 'automation', label: '自动化任务', labelEn: 'Automation Jobs', icon: 'fas fa-clock', desc: '任务管理、手动执行、模板安装与运行历史', descEn: 'Job management, manual runs, templates, and run history' },
                     { id: 'token_usage', label: 'Token 用量', labelEn: 'Token Usage', icon: 'fas fa-chart-bar', desc: 'LLM Token 使用明细与统计', descEn: 'LLM token usage details and analytics' },
-                    { id: 'logs', label: '实时日志', labelEn: 'Live Logs', icon: 'fas fa-terminal', desc: '查看后端实时运行状态', descEn: 'View backend runtime logs in real time' }
+                    { id: 'logs', label: '实时日志', labelEn: 'Live Logs', icon: 'fas fa-terminal', desc: '查看后端实时运行状态', descEn: 'View backend runtime logs in real time' },
+                    { id: 'chat', label: 'Agent 对话', labelEn: 'Agent Chat', icon: 'fas fa-comment-dots', desc: '直接与 Agent 对话调试', descEn: 'Chat with agent directly' }
                 ],
                 imPlatforms: [
                     {
@@ -2554,6 +2660,17 @@
                 config: { provider: { activeId: '', instances: [] }, channel: { activeId: null, accounts: [] }, agents: { defaults: {} } },
                 logs: [],
                 toasts: [],
+                chatMessages: [],
+                chatInput: '',
+                chatWs: null,
+                chatConnected: false,
+                chatBusy: false,
+                _chatStreamBuf: {},
+                chatPendingFiles: [],
+                chatCmdList: [],
+                chatCmdFiltered: [],
+                chatCmdShow: false,
+                chatCmdIdx: 0,
                 showGateway404: false,
                 gatewayFailCount: 0,
                 gatewayFailThreshold: 5,
@@ -3242,6 +3359,9 @@
                         if (val === 'subscriptions') {
                             this.loadChatContacts();
                         }
+                        if (val === 'chat' && !this.chatWs) {
+                            this.chatConnect();
+                        }
                     });
                     this.startGatewayHealthMonitor();
                     window.addEventListener('beforeunload', () => this.stopGatewayHealthMonitor(), { once: true });
@@ -3266,6 +3386,144 @@
                     this.showBackupViewer = true;
                 },
 
+                // ---- Chat ----
+                chatConnect() {
+                    if (this.chatWs) return;
+                    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+                    const ws = new WebSocket(`${proto}://${location.host}/ws/chat`);
+                    ws.onopen = () => {
+                        this.chatConnected = true;
+                        this.chatLoadHistory();
+                    };
+                    ws.onclose = () => {
+                        this.chatConnected = false;
+                        this.chatWs = null;
+                        // auto-reconnect if still on chat tab
+                        if (this.tab === 'chat') {
+                            setTimeout(() => this.chatConnect(), 3000);
+                        }
+                    };
+                    ws.onerror = () => { ws.close(); };
+                    ws.onmessage = (e) => {
+                        try {
+                            const data = JSON.parse(e.data);
+                            this.chatHandleMessage(data);
+                        } catch (_) {}
+                    };
+                    this.chatWs = ws;
+                },
+                chatHandleMessage(data) {
+                    if (data.type === 'message') {
+                        if (data.role === 'user') {
+                            this.chatMessages.push({ role: 'user', content: data.content, media: data.media || [] });
+                        } else {
+                            // Complete assistant message — flush stream buffer
+                            this._chatStreamBuf = {};
+                            if (!data.is_notification) this.chatBusy = false;
+                            this.chatMessages.push({ role: 'assistant', content: data.content, media: data.media || [] });
+                        }
+                        this.$nextTick(() => this.chatScrollDown());
+                    } else if (data.type === 'chunk') {
+                        const sid = data.stream_id || 'main';
+                        if (data.new_message || !this._chatStreamBuf[sid]) {
+                            // Start a new assistant bubble for this stream
+                            this._chatStreamBuf[sid] = { idx: this.chatMessages.length };
+                            this.chatMessages.push({ role: 'assistant', content: data.content });
+                        } else {
+                            const idx = this._chatStreamBuf[sid].idx;
+                            this.chatMessages[idx] = {
+                                ...this.chatMessages[idx],
+                                content: this.chatMessages[idx].content + data.content
+                            };
+                        }
+                        this.$nextTick(() => this.chatScrollDown());
+                    } else if (data.type === 'status') {
+                        this.chatBusy = data.busy;
+                    }
+                },
+                chatSend() {
+                    const text = this.chatInput.trim();
+                    const media = this.chatPendingFiles.map(f => f.path);
+                    if ((!text && !media.length) || !this.chatWs || this.chatWs.readyState !== 1) return;
+                    const payload = { type: 'message', content: text || this.chatPendingFiles.map(f => f.name).join(', ') };
+                    if (media.length) payload.media = media;
+                    this.chatWs.send(JSON.stringify(payload));
+                    this.chatInput = '';
+                    this.chatPendingFiles = [];
+                    if (this.$refs.chatInput) {
+                        this.$refs.chatInput.style.height = 'auto';
+                    }
+                },
+                chatReset() {
+                    if (!this.chatWs || this.chatWs.readyState !== 1) return;
+                    this.chatWs.send(JSON.stringify({ type: 'message', content: '/reset' }));
+                    this.chatMessages = [];
+                    this._chatStreamBuf = {};
+                    this.chatBusy = false;
+                },
+                chatScrollDown() {
+                    const el = this.$refs.chatScroll;
+                    if (el) el.scrollTop = el.scrollHeight;
+                },
+                async chatLoadHistory() {
+                    try {
+                        const res = await fetch('/api/chat/history?limit=20');
+                        if (!res.ok) return;
+                        const msgs = await res.json();
+                        if (msgs.length) {
+                            this.chatMessages = msgs;
+                            this.$nextTick(() => this.chatScrollDown());
+                        }
+                    } catch (_) {}
+                },
+                async chatLoadCommands() {
+                    if (this.chatCmdList.length) return;
+                    try {
+                        const res = await fetch('/api/chat/commands');
+                        if (res.ok) this.chatCmdList = await res.json();
+                    } catch (_) {}
+                },
+                chatCmdFilter() {
+                    const text = this.chatInput;
+                    if (!text.startsWith('/')) { this.chatCmdShow = false; return; }
+                    // Don't show autocomplete if there's already a space (user is typing args)
+                    if (text.includes(' ')) { this.chatCmdShow = false; return; }
+                    this.chatLoadCommands();
+                    const q = text.toLowerCase();
+                    this.chatCmdFiltered = this.chatCmdList.filter(c => c.name.startsWith(q));
+                    this.chatCmdIdx = 0;
+                    this.chatCmdShow = this.chatCmdFiltered.length > 0;
+                },
+                chatCmdSelect(cmd) {
+                    if (!cmd) return;
+                    this.chatInput = cmd.requires_args ? cmd.name + ' ' : cmd.name;
+                    this.chatCmdShow = false;
+                    this.$nextTick(() => { if (this.$refs.chatInput) this.$refs.chatInput.focus(); });
+                },
+                async chatUploadFile(event) {
+                    const files = event.target.files;
+                    if (!files.length) return;
+                    for (const file of files) {
+                        const form = new FormData();
+                        form.append('file', file);
+                        try {
+                            const res = await fetch('/api/chat/upload', { method: 'POST', body: form });
+                            if (!res.ok) continue;
+                            const data = await res.json();
+                            this.chatPendingFiles.push({ name: data.name, path: data.path });
+                        } catch (_) {}
+                    }
+                    event.target.value = '';
+                },
+                chatCmdScrollTo() {
+                    this.$nextTick(() => {
+                        const panel = this.$refs.chatCmdPanel;
+                        if (!panel) return;
+                        const el = panel.querySelector(`[data-cmd-idx="${this.chatCmdIdx}"]`);
+                        if (el) el.scrollIntoView({ block: 'nearest' });
+                    });
+                },
+
                 async viewDefaultConfig() {
                     if (!this.defaultConfigContent) {
                         await this.loadDefaultConfigInfo();
@@ -3279,11 +3537,13 @@
                         : '确认重启服务？进行中的对话将会中断。';
                     if (!confirm(msg)) return;
                     this.restarting = true;
-                    // Pause gateway health check to prevent the offline overlay
+                    // Pause gateway health check and reset fail state to prevent offline overlay
                     if (this._gatewayHealthTimer) {
                         clearInterval(this._gatewayHealthTimer);
                         this._gatewayHealthTimer = null;
                     }
+                    this.gatewayFailCount = 0;
+                    this.showGateway404 = false;
                     try {
                         await fetch('/api/restart', { method: 'POST' });
                     } catch (e) {


### PR DESCRIPTION
## Summary
- Add "Agent Chat" tab to WebUI — chat with the agent directly from the browser, no IM client needed
- WebSocket-based real-time communication via new `webui` channel bridging to existing MessageBus/AgentLoop
- `/` command autocomplete, file upload/download, chat history auto-load, IME compatible

## Changes
| File | Change |
|------|--------|
| `agent/services/chat_api.py` | **New** — WebSocket endpoint, history/commands/file APIs |
| `agent/services/gateway_server.py` | Register chat router (+3 lines) |
| `static/ui/index.html` | Chat tab UI, autocomplete, file handling |
| `config/commands.json` | `hidden` field for 6 internal commands |
| `config/registry.py` | `hidden` on CommandDef, `get_visible_commands()` |
| `agent/context.py` | System prompt uses `get_visible_commands()` |
| `agent/services/commands.py` | `/help` dynamically generated from commands.json |

## Test plan
- [ ] `python cli/main.py gateway --port 18790` → open `/ui` → click "Agent Chat"
- [ ] Send messages, verify agent responds
- [ ] Type `/` → verify command autocomplete appears
- [ ] Upload file via paperclip → send with Enter → verify agent receives
- [ ] Refresh page → verify chat history loads
- [ ] Click "New Conversation" → verify session resets

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)